### PR TITLE
refs #1 リポジトリ移譲に伴い、説明資料内のURLを修正

### DIFF
--- a/1.学習用ソースの準備.md
+++ b/1.学習用ソースの準備.md
@@ -15,7 +15,7 @@
 
   任意のコンソールを起動し、任意のディレクトリで以下コマンドを実行します。
 
-  `git clone -b initial_source https://github.com/jz4o/study_axlsx.git`
+  `git clone -b initial_source https://github.com/WitStudy/study_axlsx.git`
 
   Cloneが終了したら、 `study_axlsx` に移動しておきます。
 


### PR DESCRIPTION
1.学習用ソースの準備.md にて、移譲前のURLを指定している箇所を修正しました。